### PR TITLE
Use input matrix dimension when constructing diagonal matrix

### DIFF
--- a/occupancy_time_analysis.R
+++ b/occupancy_time_analysis.R
@@ -10,7 +10,7 @@ occupancy_time_analysis <- function(U){
 
   N <- solve(I-U) # fundamental matrix
   
-  Ndg<-diag(3)*N # matrix with diagonal of fundamental matrix on the diagonal, zeros elsewhere
+  Ndg<-diag(s)*N # matrix with diagonal of fundamental matrix on the diagonal, zeros elsewhere
   
   ### OCC - occupancy time - how much time do you spend in each stage?
   # moments of occupancy time


### PR DESCRIPTION
Use input matrix dimension rather than a hard-coded dimension when
constructing diagonal matrix for use in occupancy time calculations.